### PR TITLE
Add docs.rs metadata for default-target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,6 @@ winapi = { version = "0.3.6", features = ["combaseapi", "oaidl", "winerror",]}
 [build-dependencies]
 cc = "1.0.29"
 winreg = "0.6"
+
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"


### PR DESCRIPTION
Hi there! I was reviewing build logs on docs.rs and noticed your crate in the failures. Since your crate uses `winapi` items, it's failing to build in the initial attempt, which tries to build for 64-bit Linux. If you set this key in your Cargo.toml, though, it will try to build for Windows first, which should allow your docs to be hosted on docs.rs.